### PR TITLE
#34 専門薬剤師詳細を別テーブルで実装

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -11,13 +11,6 @@ class ApplicationController < ActionController::Base
 
   def configure_permitted_parameters
     devise_parameter_sanitizer.permit(:sign_up, keys: %i[name pharmacy])
-    devise_parameter_sanitizer.permit(:account_update, keys: [
-      :name, :pharmacy, :image, :image_cache, :pharmacist, :admin, :position, :introduction, 
-      pharmacist_details_attributes: [
-        :id, :office_name, :specialty, :introduction, :other_license, { license_ids: [] },
-        { disease_ids: [] }
-        ]
-      ])
   end
 
   private

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,11 +14,10 @@ class ApplicationController < ActionController::Base
     devise_parameter_sanitizer.permit(:account_update, keys: [
       :name, :pharmacy, :image, :image_cache, :pharmacist, :admin, :position, :introduction, 
       pharmacist_details_attributes: [
-        :id, :office_name, :license, :specialty, :introduction, :other_license, 
+        :id, :office_name, :specialty, :introduction, :other_license, { license_ids: [] },
         { disease_ids: [] }
         ]
-      ]
-    )
+      ])
   end
 
   private

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -2,7 +2,7 @@
 
 class Users::RegistrationsController < Devise::RegistrationsController
   # before_action :configure_sign_up_params, only: [:create]
-  # before_action :configure_account_update_params, only: [:update]
+  before_action :configure_account_update_params, only: [:update]
 
   # GET /resource/sign_up
   # def new
@@ -17,6 +17,10 @@ class Users::RegistrationsController < Devise::RegistrationsController
   # GET /resource/edit
   def edit
     @diseases = Disease.all
+    @licenses = License.all
+    unless @user.pharmacist_details.present?
+      @pharmacist_details = @user.pharmacist_details.build
+    end
     super
   end
 
@@ -59,7 +63,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
     devise_parameter_sanitizer.permit(:account_update, keys: [
       :name, :pharmacy, :image, :image_cache, :pharmacist, :admin, :position, :introduction, 
       pharmacist_details_attributes: [
-        :id, :office_name, :license, :specialty, :introduction, :other_license, 
+        :id, :office_name, :specialty, :introduction, :other_license, { license_ids: [] },
         { disease_ids: [] }
         ]
       ])

--- a/app/models/license.rb
+++ b/app/models/license.rb
@@ -1,0 +1,4 @@
+class License < ApplicationRecord
+  has_many :license_labellings, dependent: :destroy
+  has_many :pharmacist_details, through: :license_labellings
+end

--- a/app/models/license_labelling.rb
+++ b/app/models/license_labelling.rb
@@ -1,0 +1,4 @@
+class LicenseLabelling < ApplicationRecord
+  belongs_to :license
+  belongs_to :pharmacist_detail
+end

--- a/app/models/pharmacist_detail.rb
+++ b/app/models/pharmacist_detail.rb
@@ -2,9 +2,11 @@ class PharmacistDetail < ApplicationRecord
   belongs_to :user
   has_many :specialty_labellings, dependent: :destroy
   has_many :diseases, through: :specialty_labellings
+  has_many :license_labellings, dependent: :destroy
+  has_many :licenses, through: :license_labellings
 
-  enum license: {
-    "---": 0,
-    医療薬学専門薬剤師: 1, がん専門薬剤師: 2, がん指導薬剤師: 3, 外来がん治療専門薬剤師: 4, 外来がん認定薬剤師: 5
-  }
+  # enum license: {
+  #   "---": 0,
+  #   医療薬学専門薬剤師: 1, がん専門薬剤師: 2, がん指導薬剤師: 3, 外来がん治療専門薬剤師: 4, 外来がん認定薬剤師: 5
+  # }
 end

--- a/app/models/pharmacist_detail.rb
+++ b/app/models/pharmacist_detail.rb
@@ -4,9 +4,5 @@ class PharmacistDetail < ApplicationRecord
   has_many :diseases, through: :specialty_labellings
   has_many :license_labellings, dependent: :destroy
   has_many :licenses, through: :license_labellings
-
-  # enum license: {
-  #   "---": 0,
-  #   医療薬学専門薬剤師: 1, がん専門薬剤師: 2, がん指導薬剤師: 3, 外来がん治療専門薬剤師: 4, 外来がん認定薬剤師: 5
-  # }
+  
 end

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -45,7 +45,7 @@
 
             <div class="field">
               <%= pharmacist_detail.label :license %><br />
-              <%= pharmacist_detail.select :license, PharmacistDetail.licenses.keys, {}, { multiple: true, class: "form-control" } %>
+              <%= pharmacist_detail.collection_select(:license_ids, @licenses, :id, :name, { include_blank: "-資格の種類を選ぶ-", prompt: false}, { multiple: true, class: "form-control" }) %>
               <small id="licenseHelp" class="form-text text-muted">複数選択可能(windowsはctrl,Macはcommand押しながら選択)</small>
             </div>
             <br>

--- a/db/migrate/20221101020503_add_disease_detail_ref_to_questions.rb
+++ b/db/migrate/20221101020503_add_disease_detail_ref_to_questions.rb
@@ -1,5 +1,0 @@
-class AddDiseaseDetailRefToQuestions < ActiveRecord::Migration[6.0]
-  def change
-    add_reference :questions, :disease_detail, foreign_key: true
-  end
-end

--- a/db/migrate/20221228132626_create_licenses.rb
+++ b/db/migrate/20221228132626_create_licenses.rb
@@ -1,0 +1,9 @@
+class CreateLicenses < ActiveRecord::Migration[6.0]
+  def change
+    create_table :licenses do |t|
+      t.string :name, null: false
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20221228132829_create_license_labellings.rb
+++ b/db/migrate/20221228132829_create_license_labellings.rb
@@ -1,0 +1,10 @@
+class CreateLicenseLabellings < ActiveRecord::Migration[6.0]
+  def change
+    create_table :license_labellings do |t|
+      t.references :license, null: false, foreign_key: true
+      t.references :pharmacist_detail, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20230101142826_remove_license_from_pharmacist_details.rb
+++ b/db/migrate/20230101142826_remove_license_from_pharmacist_details.rb
@@ -1,0 +1,5 @@
+class RemoveLicenseFromPharmacistDetails < ActiveRecord::Migration[6.0]
+  def change
+    remove_column :pharmacist_details, :license, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_12_12_135547) do
+ActiveRecord::Schema.define(version: 2023_01_01_142826) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -66,14 +66,6 @@ ActiveRecord::Schema.define(version: 2022_12_12_135547) do
     t.index ["user_id"], name: "index_comments_on_user_id"
   end
 
-  create_table "disease_details", force: :cascade do |t|
-    t.string "content", null: false
-    t.bigint "disease_id", null: false
-    t.datetime "created_at", precision: 6, null: false
-    t.datetime "updated_at", precision: 6, null: false
-    t.index ["disease_id"], name: "index_disease_details_on_disease_id"
-  end
-
   create_table "disease_labellings", force: :cascade do |t|
     t.bigint "question_id", null: false
     t.bigint "disease_id", null: false
@@ -124,6 +116,21 @@ ActiveRecord::Schema.define(version: 2022_12_12_135547) do
     t.index ["user_id"], name: "index_impressions_on_user_id"
   end
 
+  create_table "license_labellings", force: :cascade do |t|
+    t.bigint "license_id", null: false
+    t.bigint "pharmacist_detail_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["license_id"], name: "index_license_labellings_on_license_id"
+    t.index ["pharmacist_detail_id"], name: "index_license_labellings_on_pharmacist_detail_id"
+  end
+
+  create_table "licenses", force: :cascade do |t|
+    t.string "name", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "notes", force: :cascade do |t|
     t.string "title", null: false
     t.bigint "user_id", null: false
@@ -134,7 +141,6 @@ ActiveRecord::Schema.define(version: 2022_12_12_135547) do
 
   create_table "pharmacist_details", force: :cascade do |t|
     t.string "office_name", null: false
-    t.integer "license", default: 0, null: false
     t.string "other_license"
     t.text "introduction"
     t.bigint "user_id", null: false
@@ -150,9 +156,7 @@ ActiveRecord::Schema.define(version: 2022_12_12_135547) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "disease_detail_id"
     t.integer "impressions_count", default: 0
-    t.index ["disease_detail_id"], name: "index_questions_on_disease_detail_id"
     t.index ["user_id"], name: "index_questions_on_user_id"
   end
 
@@ -194,14 +198,14 @@ ActiveRecord::Schema.define(version: 2022_12_12_135547) do
   add_foreign_key "columns", "users"
   add_foreign_key "comments", "questions"
   add_foreign_key "comments", "users"
-  add_foreign_key "disease_details", "diseases"
   add_foreign_key "disease_labellings", "diseases"
   add_foreign_key "disease_labellings", "questions"
   add_foreign_key "favorites", "questions"
   add_foreign_key "favorites", "users"
+  add_foreign_key "license_labellings", "licenses"
+  add_foreign_key "license_labellings", "pharmacist_details"
   add_foreign_key "notes", "users"
   add_foreign_key "pharmacist_details", "users"
-  add_foreign_key "questions", "disease_details"
   add_foreign_key "questions", "users"
   add_foreign_key "specialty_labellings", "diseases"
   add_foreign_key "specialty_labellings", "pharmacist_details"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -3,7 +3,7 @@ User.create!(name: "みぎたか", pharmacy: "migity", email: "migitaka@test.com
   ["すずき", "migity薬局", "suzuki@test.com", "123456", "エンジニア", 22, false, File.open('./app/assets/images/dog.png')],
   ["くりた", "ミギティー薬局", "kurita@test.com", "123456", "エンジニア", 11, false, File.open('./app/assets/images/cat.png')],
   ["やのう", "ミギー薬局", "yanou@test.com", "123456", "デザイナー", 14, false, File.open('./app/assets/images/rabbit.png')],
-  ["はぎわら", "migi薬局", "hagiwara@test.com", "123456", "薬剤師", 27, false, File.open('./app/assets/images/elephant.png')],
+  ["はぎはら", "migi薬局", "hagihara@test.com", "123456", "薬剤師", 27, false, File.open('./app/assets/images/elephant.png')],
   ["佐々木三郎", "佐々木病院", "sasaki@test.com", "123456", "がん薬物療法認定薬剤師", 13, true, File.open('./app/assets/images/sasaki.png')],
   ["岡田浩司", "東北医科薬科大学病院", "okada@test.com", "123456", "がん薬物療法認定薬剤師", 13, true, File.open('./app/assets/images/mituo.png')],
   ["山本", "山本病院", "yamamoto@test.com", "123456", "がん薬物療法認定薬剤師", 13, true, File.open('./app/assets/images/yamamoto.png')]
@@ -113,14 +113,14 @@ Comment.create!(user_id: 7, question_id: 5, content: "そのがんについて�
 Comment.create!(user_id: 7, question_id: 6, content: "そのがんについては…", best_answer: true)
 Comment.create!(user_id: 8, question_id: 7, content: "そのがんについては…", best_answer: true)
 
-pharmacist_licenses = [
-  "がん専門薬剤師", "がん指導薬剤師", "医療薬学専門薬剤師", "外来がん治療専門薬剤師", "外来がん認定薬剤師"
+licenses = [
+  "医療薬学専門薬剤師", "がん専門薬剤師", "がん指導薬剤師", "外来がん治療専門薬剤師", "外来がん認定薬剤師"
 ]
-pharmacist_licenses.each do |license|
+licenses.each do |license|
   License.create!(name: license)
-end 1678
+end
 
-LicenseLabelling.create!(user_id: 1, license_id: 1)
-LicenseLabelling.create!(user_id: 6, license_id: 1, 3)
-LicenseLabelling.create!(user_id: 7, license_id: 1, 2, 3)
-LicenseLabelling.create!(user_id: 8, license_id: 1, 2, 3, 4, 5)
+PharmacistDetail.create!(office_name: "株式会社migity", user_id: 1, )
+PharmacistDetail.create!(office_name: "佐々木病院", user_id: 6, )
+PharmacistDetail.create!(office_name: "岡田総合病院", user_id: 7, )
+PharmacistDetail.create!(office_name: "山本病院", user_id: 8, )

--- a/spec/factories/license_labellings.rb
+++ b/spec/factories/license_labellings.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :license_labelling do
+    license { nil }
+    pharmacist_detail { nil }
+  end
+end

--- a/spec/factories/licenses.rb
+++ b/spec/factories/licenses.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :license do
+    name { "MyString" }
+  end
+end

--- a/spec/models/license_labelling_spec.rb
+++ b/spec/models/license_labelling_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe LicenseLabelling, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/license_spec.rb
+++ b/spec/models/license_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe License, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end


### PR DESCRIPTION
一般ユーザーが使用しない資格や自己紹介などのカラムを別テーブルで管理
 カラム（勤務地（病院名など）、資格、その他資格、得意分野、自己紹介、user_id）
 userテーブルにアソシエーション
 user/editでは親テーブルと一緒に変更できるようにする
 user/editでは一般ユーザーの編集時に表示させないようにする

上記内容について実装を行いました。