### PR TITLE
#46 QAを知見に変更

### DIFF
--- a/app/controllers/knowledges_controller.rb
+++ b/app/controllers/knowledges_controller.rb
@@ -1,13 +1,13 @@
 class KnowledgesController < ApplicationController
   before_action :authenticate_user!, only: %i[new create edit update destroy]
   before_action :set_knowledge, only: %i[show edit update destroy change_resolved]
-  before_action :other_than_drafts, only: %i[index search my]
+  before_action :other_than_drafts, only: %i[index search my expert_view_index]
   before_action :diseases, only: %i[new edit create confirm]
   before_action :drugs, only: %i[new edit create confirm]
   before_action :side_effects, only: %i[new edit create confirm]
-  before_action :knowledge_tag_ranks, only: %i[index show by_disease by_drug by_side_effect search my]
+  before_action :knowledge_tag_ranks, only: %i[index show by_disease by_drug by_side_effect search my expert_view_index]
   before_action :half_width_to_full_width, only: %i[update confirm]
-  before_action :sidebar_profession_users, only: %i[index show by_disease by_drug by_side_effect search my tag_index]
+  before_action :sidebar_profession_users, only: %i[index show by_disease by_drug by_side_effect search my tag_index expert_view_index]
 
   def index
     @knowledges = @knowledges.where(resolved: true).order("created_at DESC").page(params[:page]).per(5) if params[:resolved]
@@ -125,6 +125,15 @@ class KnowledgesController < ApplicationController
     @all_disease_tags = Disease.all
     @all_drug_tags = Drug.all
     @all_side_effect_tags = SideEffect.all
+  end
+
+  def expert_view_index
+    if current_user.expert?
+      @knowledges = @knowledges.where(resolved: true).order("created_at DESC").page(params[:page]).per(5) if params[:resolved]
+      @knowledges = @knowledges.where(resolved: false).order("created_at DESC").page(params[:page]).per(5) if params[:unresolved]
+    else
+      render :index
+    end
   end
 
   private

--- a/app/controllers/knowledges_controller.rb
+++ b/app/controllers/knowledges_controller.rb
@@ -1,5 +1,5 @@
 class KnowledgesController < ApplicationController
-  before_action :authenticate_user!, only: %i[new create edit update destroy]
+  before_action :authenticate_user!, only: %i[new create edit update destroy show]
   before_action :set_knowledge, only: %i[show edit update destroy change_resolved]
   before_action :other_than_drafts, only: %i[index search my expert_view_index]
   before_action :diseases, only: %i[new edit create confirm]

--- a/app/views/favorites/_favorite.html.erb
+++ b/app/views/favorites/_favorite.html.erb
@@ -3,14 +3,14 @@
   <% unless @knowledge.user_id == current_user.id %>
     <% if current_user.favorites.find_by(knowledge_id: @knowledge.id) %>
       <%= link_to favorite_path(@knowledge.id, current_user.favorites.find_by(knowledge_id: @knowledge.id)), method: :delete, remote: true do %>
-        <span class="clip-text"><%= embedded_svg("clip.svg") %>クリップ解除</span>
+        <span class="clip-text"><small><%= embedded_svg("clip.svg") %>保存解除</small></span>
       <% end %>
       <%= @knowledge.favorites.count %>
     <% else %>
       <%= link_to favorites_path(knowledge_id: @knowledge.id), method: :post, remote: true do %>
-        <span class="clip-text"><%= embedded_svg("clip.svg") %>クリップ</span>
+        <span class="clip-text"><small><%= embedded_svg("clip.svg") %>保存</small></span>
       <% end %>
-      <%= @knowledge.favorites.count %>
+      <small><%= @knowledge.favorites.count %></small>
     <% end %>
   <% end %>
 <% end %>

--- a/app/views/knowledges/expert_view_index.html.erb
+++ b/app/views/knowledges/expert_view_index.html.erb
@@ -1,4 +1,3 @@
-<%= render "knowledges/shared/jumbotron" %>
 <%= render "knowledges/shared/notice" %>
 
 <div class="container main-container">
@@ -7,7 +6,14 @@
       <div class="container">
         <div class="row">
           <div class="col-md-6">
-            <h3>知見一覧</h3>
+            <h3>質問投稿一覧</h3>
+          </div>
+          <div class="col-md-6 text-right">
+            <span>
+              <%= link_to "すべて", expert_view_index_knowledges_path, class: "btn btn-outline-secondary" %>
+              <%= link_to "解決済み", expert_view_index_knowledges_path(resolved: true), class: "btn btn-outline-secondary" %>
+              <%= link_to "回答受付中", expert_view_index_knowledges_path(unresolved: true), class: "btn btn-outline-secondary" %>
+            </span>
           </div>
         </div>
       </div>
@@ -18,14 +24,18 @@
             <div class="col-md-2">
               <div class="bd-placeholder">
                 <br>
-                <p class="text-center bottom-mgr-5"><small>回答数 <%= comment_count(knowledge) %></small></p>
-                <p class="text-center bottom-mgr-5"><small>保存数 <%= knowledge.favorites.count %></small></p>
-                <p class="text-center bottom-mgr-5"><small>閲覧数 <%= knowledge.impressions_count %></small></p>
+                <% if knowledge.resolved %>
+                  <p class="resolved-true text-center bottom-mgr-5"><small><%= resolved_text(knowledge) %></small></p>
+                <% else %>
+                  <p class="resolved-false text-center bottom-mgr-5"><small><%= resolved_text(knowledge) %></small></p>
+                <% end %>
+                <p class="text-center bottom-mgr-5"><small>回答数<%= comment_count(knowledge) %></small></p>
+                <p class="text-center bottom-mgr-5"><small>保存数<%= knowledge.favorites.count %></small></p>
               </div>
             </div>
             <div class="col-md-10">
               <%= link_to knowledge_path(knowledge.id), class: "card-body knowledge-index" do %>
-                <h4 class="card-title"><strong><%= knowledge.title %></strong></h4>
+                <h5 class="card-title"><%= knowledge.title %></h5>
                 <p class="card-text"><%= strip_tags(knowledge.content.to_s).gsub(/[\n]/,"").strip %></p>
               <% end %>
             </div>

--- a/app/views/knowledges/show.html.erb
+++ b/app/views/knowledges/show.html.erb
@@ -32,18 +32,12 @@
                 </small>
               </div>
               <div class="col-2 text-right">
-                <strong>閲覧数<%= @knowledge.impressions_count %></strong>
+                <small>閲覧数<%= @knowledge.impressions_count %></small>
               </div>
               <div class="col-3 text-center">
-                <% if user_signed_in? %>
-                  <% if @knowledge.user_id == current_user.id %>
-                    <strong>クリップ数<%= @knowledge.favorites.count %></strong>
-                  <% else %>
-                    <div class="favorite-link" id="favorite-link-<%= @knowledge.id %>">
-                      <%= render partial: 'favorites/favorite', locals: { knowledge: @knowledge } %>
-                    </div>
-                  <% end %>
-                <% end %>
+                <div class="favorite-link" id="favorite-link-<%= @knowledge.id %>">
+                  <%= render partial: 'favorites/favorite', locals: { knowledge: @knowledge } %>
+                </div>
               </div>
             </div>
           </div>
@@ -73,15 +67,12 @@
         </div>
       </div>
       <div class="card mb-3 border border-0">
-        <p>閲覧数<%= @knowledge.impressions_count %></p>
-          <%= render "knowledges/shared/best_answer" %>
+        <%= render "knowledges/shared/best_answer" %>
         <div id="comments_area">
           <%= render partial: 'comments/index', locals: { comments: @comments, knowledge: @knowledge } %>
         </div>
-        <% if user_signed_in? %>
+        <% if current_user.expert? %>
           <%= render partial: 'comments/form', locals: { comment: @comment, knowledge: @knowledge } %>
-        <% else %>
-          <p>※コメントは登録後投稿できます</p>
         <% end %>
       </div>
     </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -43,8 +43,11 @@
                       <%= image_tag "no_image.png", class: "rounded-circle mgr-20", size: "40x40" %>
                     <% end %>
                     <div class="dropdown-menu dropdown-menu-right">
-                      <%= link_to user_path(current_user.id), class: "dropdown-item" do %><%= embedded_svg("account.svg") %>マイページ<% end %>
+                      <%= link_to my_knowledges_path(current_user.id), class: "dropdown-item" do %><%= embedded_svg("account.svg") %>マイページ<% end %>
                       <%= link_to edit_user_registration_path(current_user.id), class: "dropdown-item" do %><%= embedded_svg("edit.svg") %>プロフィール<% end %>
+                      <% if current_user.expert? %>
+                        <%= link_to expert_view_index_knowledges_path(current_user.id), class: "dropdown-item" do %><%= embedded_svg("knowledge-answer.svg") %>質問投稿一覧<% end %>
+                      <% end %>
                       <%= link_to destroy_user_session_path, method: :delete, class: "dropdown-item" do %><%= embedded_svg("logout.svg") %>ログアウト<% end %>
                     </div>
                   </a>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,6 +31,7 @@ Rails.application.routes.draw do
       get :by_side_effect
       get :my
       get :tag_index
+      get :expert_view_index
     end
     member do
       get :change_resolved


### PR DESCRIPTION
 questionsテーブル名knowledgesに変更
 question/indexから回答受付中を表示しない
 question/indexの一覧をがん・支持療法・薬名のタブ一覧ページを作成
 question/showのコメント機能はエキスパートのみできる
 question/indexを新たに作成しエキスパートのみが受付中の質問一覧を見れるようにする
 エキスパートの方で「すべて」「解決済み」「回答受付中」で並び替えできるようにする
 未ログイン者は知見の詳細は見れないようにする

上記実装完了しました