### PR TITLE
[fix]AWSのEC2からlightsailに変更

### DIFF
--- a/config/deploy/production.rb
+++ b/config/deploy/production.rb
@@ -1,2 +1,2 @@
-server '18.178.95.68', user: 'app', roles: %w{app db web}
+server '35.79.234.81', user: 'app', roles: %w{app db web}
 set :ssh_options, keys: '/Users/suzukishouta/.ssh/id_rsa'


### PR DESCRIPTION
現在AWSのEC2にインスタンスがあるが、安価なlightsailにインスタンスを移動する
[Amazon LightsailでRailsアプリをデプロイしたい（PostgreSQL）](https://qiita.com/kakudaisuke/items/f38938552ee9456a23f6)
[【Rails】 AWSのEC2にデプロイする方法~画像で丁寧に解説！](https://pikawaka.com/rails/ec2_deploy)